### PR TITLE
SLING-13178 Logout link from the WebConsole UI fails to logout

### DIFF
--- a/src/main/java/org/apache/sling/extensions/webconsolesecurityprovider/internal/ServicesListener.java
+++ b/src/main/java/org/apache/sling/extensions/webconsolesecurityprovider/internal/ServicesListener.java
@@ -24,6 +24,7 @@ import java.util.Hashtable;
 import java.util.Objects;
 
 import org.apache.felix.webconsole.spi.SecurityProvider;
+import org.jetbrains.annotations.NotNull;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.Constants;
 import org.osgi.framework.InvalidSyntaxException;
@@ -193,7 +194,7 @@ public class ServicesListener {
      *
      * @return the resolved context path or empty string otherwise
      */
-    private String resolveSlingServletContextPath() {
+    private @NotNull String resolveSlingServletContextPath() {
         Object value = null;
         Collection<ServiceReference<ServletContextHelper>> serviceReferences;
         try {

--- a/src/main/java/org/apache/sling/extensions/webconsolesecurityprovider/internal/ServicesListener.java
+++ b/src/main/java/org/apache/sling/extensions/webconsolesecurityprovider/internal/ServicesListener.java
@@ -18,8 +18,10 @@
  */
 package org.apache.sling.extensions.webconsolesecurityprovider.internal;
 
+import java.util.Collection;
 import java.util.Dictionary;
 import java.util.Hashtable;
+import java.util.Objects;
 
 import org.apache.felix.webconsole.spi.SecurityProvider;
 import org.osgi.framework.BundleContext;
@@ -30,6 +32,9 @@ import org.osgi.framework.ServiceListener;
 import org.osgi.framework.ServiceReference;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.cm.ManagedService;
+import org.osgi.service.http.context.ServletContextHelper;
+import org.osgi.service.http.whiteboard.HttpWhiteboardConstants;
+import org.osgi.util.converter.Converters;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -183,15 +188,40 @@ public class ServicesListener {
         }
     }
 
+    /**
+     * SLING-13178 resolves the context path of the "org.apache.sling" servlet context
+     *
+     * @return the resolved context path or empty string otherwise
+     */
+    private String resolveSlingServletContextPath() {
+        Object value = null;
+        Collection<ServiceReference<ServletContextHelper>> serviceReferences;
+        try {
+            String filter =
+                    String.format("(%s=org.apache.sling)", HttpWhiteboardConstants.HTTP_WHITEBOARD_CONTEXT_NAME);
+            serviceReferences = bundleContext.getServiceReferences(ServletContextHelper.class, filter);
+            value = serviceReferences.stream()
+                    .map(sr -> sr.getProperty(HttpWhiteboardConstants.HTTP_WHITEBOARD_CONTEXT_PATH))
+                    .filter(Objects::nonNull)
+                    .findFirst()
+                    .orElse(null);
+        } catch (InvalidSyntaxException e) {
+            // should never get here
+            logger.warn("Failed to get servlet context helper", e);
+        }
+        return Converters.standardConverter().convert(value).defaultValue("").to(String.class);
+    }
+
     private void registerProviderSling(final Object authSupport, final Object authenticator) {
         final Dictionary<String, Object> props = new Hashtable<>();
         props.put(Constants.SERVICE_PID, SlingWebConsoleSecurityProvider.class.getName());
         props.put(Constants.SERVICE_DESCRIPTION, "Apache Sling Web Console Security Provider 2");
         props.put(Constants.SERVICE_VENDOR, "The Apache Software Foundation");
         props.put("webconsole.security.provider.id", "org.apache.sling.extensions.webconsolesecurityprovider2");
+        final String slingServletContextPath = resolveSlingServletContextPath();
         this.provider2Reg = this.bundleContext.registerService(
                 new String[] {ManagedService.class.getName(), SecurityProvider.class.getName()},
-                new SlingWebConsoleSecurityProvider2(authSupport, authenticator),
+                new SlingWebConsoleSecurityProvider2(authSupport, authenticator, slingServletContextPath),
                 props);
     }
 

--- a/src/main/java/org/apache/sling/extensions/webconsolesecurityprovider/internal/SlingWebConsoleSecurityProvider2.java
+++ b/src/main/java/org/apache/sling/extensions/webconsolesecurityprovider/internal/SlingWebConsoleSecurityProvider2.java
@@ -26,6 +26,7 @@ import java.util.Iterator;
 import java.util.Set;
 
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
 import jakarta.servlet.http.HttpServletResponse;
 import org.apache.felix.webconsole.spi.SecurityProvider;
 import org.apache.jackrabbit.api.JackrabbitSession;
@@ -74,9 +75,13 @@ public class SlingWebConsoleSecurityProvider2 implements SecurityProvider, Manag
 
     private final Authenticator authenticator;
 
-    public SlingWebConsoleSecurityProvider2(@NotNull final Object support, @NotNull final Object authenticator) {
+    private String slingContextPath;
+
+    public SlingWebConsoleSecurityProvider2(
+            @NotNull final Object support, @NotNull final Object authenticator, String slingContextPath) {
         this.authentiationSupport = (AuthenticationSupport) support;
         this.authenticator = (Authenticator) authenticator;
+        this.slingContextPath = slingContextPath;
     }
 
     /**
@@ -176,6 +181,16 @@ public class SlingWebConsoleSecurityProvider2 implements SecurityProvider, Manag
 
     @Override
     public void logout(@NotNull HttpServletRequest request, @NotNull HttpServletResponse response) {
-        this.authenticator.logout(request, response);
+        // SLING-13178 - we want the context path to be whatever was used to login
+        //   to ensure the sling.formauth cookie using the same "path" value when
+        //   clearing the cookie
+        HttpServletRequest wrappedRequest = new HttpServletRequestWrapper(request) {
+            @Override
+            public String getContextPath() {
+                return slingContextPath;
+            }
+        };
+
+        this.authenticator.logout(wrappedRequest, response);
     }
 }

--- a/src/main/java/org/apache/sling/extensions/webconsolesecurityprovider/internal/SlingWebConsoleSecurityProvider2.java
+++ b/src/main/java/org/apache/sling/extensions/webconsolesecurityprovider/internal/SlingWebConsoleSecurityProvider2.java
@@ -75,10 +75,10 @@ public class SlingWebConsoleSecurityProvider2 implements SecurityProvider, Manag
 
     private final Authenticator authenticator;
 
-    private String slingContextPath;
+    private final String slingContextPath;
 
     public SlingWebConsoleSecurityProvider2(
-            @NotNull final Object support, @NotNull final Object authenticator, String slingContextPath) {
+            @NotNull final Object support, @NotNull final Object authenticator, @NotNull String slingContextPath) {
         this.authentiationSupport = (AuthenticationSupport) support;
         this.authenticator = (Authenticator) authenticator;
         this.slingContextPath = slingContextPath;

--- a/src/test/java/org/apache/sling/extensions/webconsolesecurityprovider/internal/SlingWebConsoleSecurityProvider2Test.java
+++ b/src/test/java/org/apache/sling/extensions/webconsolesecurityprovider/internal/SlingWebConsoleSecurityProvider2Test.java
@@ -67,7 +67,7 @@ public class SlingWebConsoleSecurityProvider2Test {
     public void before() {
         support = Mockito.mock(AuthenticationSupport.class);
         authenticator = Mockito.mock(Authenticator.class);
-        provider = new SlingWebConsoleSecurityProvider2(support, authenticator);
+        provider = new SlingWebConsoleSecurityProvider2(support, authenticator, "");
     }
 
     /**


### PR DESCRIPTION
When using the starter app, the initial webconsole login action sets the sling.formauth cookie path to "/".  But the action from the logout link attempts to clear the sling.formauth cookie with a path of "/system/console".  Since the path doesn't match what was stored in the client browser it does not clear the original cookie and the user remains logged in.